### PR TITLE
CustomSearchBar refactor

### DIFF
--- a/movie_shape/lib/views/favourites/favourites_view.dart
+++ b/movie_shape/lib/views/favourites/favourites_view.dart
@@ -24,11 +24,16 @@ class FavouritesView extends StatelessWidget {
 
     return Column(
       children: [
-        CustomSearchBar(onSearchResults: (searchQuery) {
-          context
-              .read<FavouritesListBloc>()
-              .add(SearchFavouritesList(searchQuery));
-        }),
+        CustomSearchBar(
+          onSearchResults: (searchQuery) {
+            context
+                .read<FavouritesListBloc>()
+                .add(SearchFavouritesList(searchQuery));
+          },
+          onClear: () {
+            context.read<FavouritesListBloc>().add(ClearFavouritesSearch());
+          },
+        ),
         Expanded(
           child: BlocBuilder<FavouritesListBloc, FavouritesListState>(
             builder: (context, state) {

--- a/movie_shape/lib/views/favourites/favourites_view.dart
+++ b/movie_shape/lib/views/favourites/favourites_view.dart
@@ -33,6 +33,7 @@ class FavouritesView extends StatelessWidget {
           onClear: () {
             context.read<FavouritesListBloc>().add(ClearFavouritesSearch());
           },
+          hintText: "Search your Favourites List...",
         ),
         Expanded(
           child: BlocBuilder<FavouritesListBloc, FavouritesListState>(

--- a/movie_shape/lib/views/favourites/favourites_view.dart
+++ b/movie_shape/lib/views/favourites/favourites_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:movie_shape/views/favourites/state/favourites_list_bloc/favourites_list_bloc.dart';
-import 'package:movie_shape/helpers/constants.dart';
 import 'package:movie_shape/repository/film_repo_implemented.dart';
 import 'package:movie_shape/models/film.dart';
 import 'package:movie_shape/views/pages/film_detail_page.dart';

--- a/movie_shape/lib/views/favourites/state/favourites_list_bloc/favourites_list_bloc.dart
+++ b/movie_shape/lib/views/favourites/state/favourites_list_bloc/favourites_list_bloc.dart
@@ -12,6 +12,7 @@ class FavouritesListBloc
   FavouritesListBloc() : super(FavouritesListInitial()) {
     on<LoadFavouritesList>(_onLoadFavouritesList);
     on<SearchFavouritesList>(_onSearchFavouritesList);
+    on<ClearFavouritesSearch>(_onClearFavouritesSearch);
   }
 
   void _onLoadFavouritesList(event, emit) async {
@@ -43,6 +44,17 @@ class FavouritesListBloc
       } else {
         emit(FavouritesListLoaded(favouritesList));
       }
+    } catch (e) {
+      emit(FavouritesListError(e.toString()));
+    }
+  }
+
+  void _onClearFavouritesSearch(event, emit) async {
+    try {
+      emit(FavouritesListLoading());
+      List<FilmSummary> favouritesList =
+          await FilmRepoImplemented().getFavouritedFilms() ?? [];
+      emit(FavouritesListLoaded(favouritesList));
     } catch (e) {
       emit(FavouritesListError(e.toString()));
     }

--- a/movie_shape/lib/views/favourites/state/favourites_list_bloc/favourites_list_event.dart
+++ b/movie_shape/lib/views/favourites/state/favourites_list_bloc/favourites_list_event.dart
@@ -11,3 +11,7 @@ class SearchFavouritesList extends FavouritesListEvent {
   final String searchQuery;
   SearchFavouritesList(this.searchQuery);
 }
+
+class ClearFavouritesSearch extends FavouritesListEvent {
+  ClearFavouritesSearch();
+}

--- a/movie_shape/lib/views/homepage/home_view.dart
+++ b/movie_shape/lib/views/homepage/home_view.dart
@@ -24,9 +24,12 @@ class HomeView extends StatelessWidget {
 
     return Column(
       children: [
-        CustomSearchBar(onSearchResults: (searchQuery) {
-          context.read<HomeBloc>().add(OnSearchSubmit(searchQuery));
-        }),
+        CustomSearchBar(
+          onSearchResults: (searchQuery) {
+            context.read<HomeBloc>().add(OnSearchSubmit(searchQuery));
+          },
+          hintText: "Search for a film...",
+        ),
         Expanded(
           child: BlocBuilder<HomeBloc, HomeState>(
             builder: (context, state) {

--- a/movie_shape/lib/views/watchlist/state/watchlist_bloc/watchlist_bloc.dart
+++ b/movie_shape/lib/views/watchlist/state/watchlist_bloc/watchlist_bloc.dart
@@ -41,5 +41,15 @@ class WatchlistBloc extends Bloc<WatchlistEvent, WatchlistState> {
         emit(WatchlistError(e.toString()));
       }
     });
+    on<ClearWatchSearch>((event, emit) async {
+      try {
+        emit(WatchlistLoading());
+        List<FilmSummary> watchlist =
+            await FilmRepoImplemented().getWatchlistFilms() ?? [];
+        emit(WatchlistLoaded(watchlist));
+      } catch (e) {
+        emit(WatchlistError(e.toString()));
+      }
+    });
   }
 }

--- a/movie_shape/lib/views/watchlist/state/watchlist_bloc/watchlist_event.dart
+++ b/movie_shape/lib/views/watchlist/state/watchlist_bloc/watchlist_event.dart
@@ -12,3 +12,7 @@ class SearchWatchlist extends WatchlistEvent {
   final String searchQuery;
   const SearchWatchlist(this.searchQuery);
 }
+
+class ClearWatchSearch extends WatchlistEvent {
+  const ClearWatchSearch();
+}

--- a/movie_shape/lib/views/watchlist/watchlist_view.dart
+++ b/movie_shape/lib/views/watchlist/watchlist_view.dart
@@ -30,6 +30,7 @@ class WatchlistView extends StatelessWidget {
           },
           onClear: () =>
               {context.read<WatchlistBloc>().add(ClearWatchSearch())},
+          hintText: "Search your Watch List...",
         ),
         Expanded(
           child: BlocBuilder<WatchlistBloc, WatchlistState>(

--- a/movie_shape/lib/views/watchlist/watchlist_view.dart
+++ b/movie_shape/lib/views/watchlist/watchlist_view.dart
@@ -24,9 +24,13 @@ class WatchlistView extends StatelessWidget {
 
     return Column(
       children: [
-        CustomSearchBar(onSearchResults: (searchQuery) {
-          context.read<WatchlistBloc>().add(SearchWatchlist(searchQuery));
-        }),
+        CustomSearchBar(
+          onSearchResults: (searchQuery) {
+            context.read<WatchlistBloc>().add(SearchWatchlist(searchQuery));
+          },
+          onClear: () =>
+              {context.read<WatchlistBloc>().add(ClearWatchSearch())},
+        ),
         Expanded(
           child: BlocBuilder<WatchlistBloc, WatchlistState>(
             builder: (context, state) {

--- a/movie_shape/lib/views/widgets/searchbar.dart
+++ b/movie_shape/lib/views/widgets/searchbar.dart
@@ -2,13 +2,21 @@ import 'package:flutter/material.dart';
 
 class CustomSearchBar extends StatelessWidget {
   final Function(String) onSearchResults;
+  final VoidCallback? onClear;
 
-  CustomSearchBar({super.key, required this.onSearchResults});
+  CustomSearchBar({super.key, required this.onSearchResults, this.onClear});
 
   final TextEditingController _controller = TextEditingController();
 
   void _handleSearch(String title) {
     onSearchResults(title);
+  }
+
+  void _handleClear() {
+    _controller.clear();
+    if (onClear != null) {
+      onClear!();
+    }
   }
 
   @override
@@ -20,6 +28,9 @@ class CustomSearchBar extends StatelessWidget {
         _handleSearch(value);
       },
       leading: Icon(Icons.search),
+      trailing: onClear != null
+          ? [IconButton(onPressed: _handleClear, icon: Icon(Icons.clear))]
+          : null,
     );
   }
 }

--- a/movie_shape/lib/views/widgets/searchbar.dart
+++ b/movie_shape/lib/views/widgets/searchbar.dart
@@ -3,8 +3,13 @@ import 'package:flutter/material.dart';
 class CustomSearchBar extends StatelessWidget {
   final Function(String) onSearchResults;
   final VoidCallback? onClear;
+  final String hintText;
 
-  CustomSearchBar({super.key, required this.onSearchResults, this.onClear});
+  CustomSearchBar(
+      {super.key,
+      required this.onSearchResults,
+      this.onClear,
+      required this.hintText});
 
   final TextEditingController _controller = TextEditingController();
 
@@ -22,7 +27,7 @@ class CustomSearchBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SearchBar(
-      hintText: "Search for a film...",
+      hintText: hintText,
       controller: _controller,
       onSubmitted: (value) {
         _handleSearch(value);


### PR DESCRIPTION
Give users the ability to clear their search results from a filtered favourites or watchlist screen. Additionally, replaces searchbar hintText with a required parameter, identifying the page contextually.